### PR TITLE
properbly escape $PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,5 +37,5 @@ echo "-----> Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 
 cat <<EOF > $BUILD_DIR/.profile.d/phantomjs.sh
-export PATH="$HOME/vendor/phantomjs/bin:$PATH"
+export PATH="$HOME/vendor/phantomjs/bin:\$PATH"
 EOF


### PR DESCRIPTION
at the moment this buildpack exposes the wrong $PATH to the dynos, which is the ruby based build envoironment

``` bash
~ $ cat .profile.d/phantomjs.sh
export PATH="/app/vendor/phantomjs/bin:/app/bin:/app/vendor/bundle/bin:/app/vendor/bundle/ruby/1.9.1/bin:vendor/bundle/ruby/1.9.1/bin:/usr/local/bin:/usr/bin:/bin:bin:/tmp/codon/vendor/bin"
```
